### PR TITLE
Use absolute link to notebook, for pypi.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,4 +3,4 @@
 Python implementation of NBEATS model
 
 # Run example
-A full example available in [Nbeats.ipynb](Nbeats.ipynb)
+A full example available in [Nbeats.ipynb](https://github.com/autonlab/nbeats/blob/master/Nbeats.ipynb)


### PR DESCRIPTION
Right now the link on https://pypi.org/project/d3m-nbeats/0.1.0/ is dead